### PR TITLE
Fix path and dataset normalization

### DIFF
--- a/ios_implementation/CAMUSSegmentationModel.swift
+++ b/ios_implementation/CAMUSSegmentationModel.swift
@@ -26,6 +26,10 @@ class CAMUSSegmentationModel {
     
     private let expectedInputName = "input"     // Adjust based on actual model
     private let expectedOutputName = "output"   // Adjust based on actual model
+
+    // Normalization constants from training dataset
+    private let intensityMean: Float = 76.2786
+    private let intensityStd: Float = 47.6041
     
     // MARK: - Initialization
     
@@ -245,8 +249,8 @@ extension CAMUSSegmentationModel {
             return nil
         }
         
-        // Step 3: Normalize to [0, 1] range (matching training preprocessing)
-        let normalizedData = pixelData.map { Float($0) / 255.0 }
+        // Step 3: Z-score normalization using the training dataset statistics
+        let normalizedData = pixelData.map { (Float($0) - intensityMean) / intensityStd }
         
         // Verify data size
         let expectedSize = 256 * 256

--- a/ios_test_app/CAMUSSegmentationModel.swift
+++ b/ios_test_app/CAMUSSegmentationModel.swift
@@ -23,9 +23,13 @@ class CAMUSSegmentationModel {
     // Model specifications (from our successful conversion)
     private let inputShape = [1, 1, 256, 256]  // [batch, channel, height, width]
     private let outputShape = [1, 3, 256, 256] // [batch, classes, height, width]
-    
+
     private let expectedInputName = "input"     // Adjust based on actual model
     private let expectedOutputName = "output"   // Adjust based on actual model
+
+    // Normalization constants from training dataset (Z-score)
+    private let intensityMean: Float = 76.2786
+    private let intensityStd: Float = 47.6041
     
     // MARK: - Initialization
     
@@ -244,8 +248,8 @@ extension CAMUSSegmentationModel {
             return nil
         }
         
-        // Step 3: Normalize to [0, 1] range (matching training preprocessing)
-        let normalizedData = pixelData.map { Float($0) / 255.0 }
+        // Step 3: Z-score normalization using training dataset statistics
+        let normalizedData = pixelData.map { (Float($0) - intensityMean) / intensityStd }
         
         // Verify data size
         let expectedSize = 256 * 256

--- a/load_actual_weights.py
+++ b/load_actual_weights.py
@@ -8,6 +8,7 @@ Purpose: Map and load the actual checkpoint weights into our reconstructed model
 import torch
 import torch.nn as nn
 from collections import OrderedDict
+from pathlib import Path
 from reconstruct_nnunet import ReconstructednnUNet, analyze_nnunet_structure
 
 def create_weight_mapping(model_state_dict, checkpoint_state_dict):
@@ -317,7 +318,9 @@ def main():
     print("=" * 45)
     
     # Load the checkpoint
-    model_path = "/workspaces/Scrollshot_Fixer/model_files/Segmentation model/checkpoint_best.pth"
+    # Use a path relative to this file so the script works from any environment
+    repo_root = Path(__file__).resolve().parent
+    model_path = repo_root / "model_files" / "Segmentation model" / "checkpoint_best.pth"
     checkpoint = torch.load(model_path, map_location='cpu', weights_only=False)
     state_dict = checkpoint['network_weights']
     


### PR DESCRIPTION
## Summary
- use relative path when loading segmentation weights
- normalize images using dataset Z-score in iOS examples

## Testing
- `python3 final_onnx_conversion.py`


------
https://chatgpt.com/codex/tasks/task_e_6843581ebe50832f804b9a4b680c3fee